### PR TITLE
[Important!] This PR removes 1 vulnerable method call, 2 high-risk vulnerabilities, 9 medium-risk vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,10 @@ limitations under the License.
     <avro.version>1.7.4</avro.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
     <checkstyle.tool.version>6.19</checkstyle.tool.version>
-    <elasticsearch.version>0.90.1</elasticsearch.version>
+    <elasticsearch.version>5.1.1</elasticsearch.version>
     <hadoop2.version>2.4.0</hadoop2.version>
     <thrift.version>0.7.0</thrift.version>
-    <kafka.version>0.9.0.1</kafka.version>
+    <kafka.version>0.10.1.0</kafka.version>
     <kite.version>1.0.0</kite.version>
     <hive.version>1.0.0</hive.version>
     <xalan.verion>2.7.1</xalan.verion>
@@ -964,7 +964,7 @@ limitations under the License.
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.2.1</version>
+        <version>4.5.2</version>
       </dependency>
 
       <dependency>
@@ -1014,7 +1014,7 @@ limitations under the License.
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
-        <version>10.11.1.1</version>
+        <version>10.13.1.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
![SourceClear logo](https://www.sourceclear.com/images/SourceClear_Logo_Primary_Black.png)
Greetings from [SourceClear](https://www.sourceclear.com)! We scanned your repo and found the following vulnerabilities in your direct dependencies. We created this Pull Request to fix them for you.

To find out more about the vulnerabilities, you can search for them in our [SourceClear Registry](https://www.sourceclear.com/registry/explore).

### The details of the vulnerabilities that we fixed are:
#### Vulnerable method calls
 - Method `isSecureZooKeeper` in class `org/apache/hadoop/hbase/zookeeper/ZKUtil` in org.apache.hbase:hbase-client:1.0.0
#### High-risk vulnerabilities
 - **Arbitrary Shell Command Execution in the Groovy Scripting Engine** in org.elasticsearch:elasticsearch:0.90.1
 - **Denial of Service (DoS) and Information Disclosure** in org.apache.hbase:hbase-client:1.0.0
#### Medium-risk vulnerabilities
 - **Man-in-the-Middle (MitM) Attack Due to Insecure Defaults** in org.apache.kafka:kafka-clients:0.9.0.1
 - **Cross-site Scripting (XSS) in the CORS Functionality** in org.elasticsearch:elasticsearch:0.90.1
 - **Remote Code Execution When Dynamic Scripting is Disabled** in org.elasticsearch:elasticsearch:0.90.1
 - **XML External Entity (XXE), Information Disclosure and, Denial of Service (DoS)** in org.apache.derby:derby:10.11.1.1
 - **Cross-Site Tracing** in org.apache.hadoop:hadoop-common:2.4.0
 - **Cross-Site Scripting (XSS)** in org.apache.hadoop:hadoop-common:2.4.0
 - **Leakage of File System Information** in org.apache.hadoop:hadoop-hdfs:2.4.0
 - **Man in the Middle (MitM) Attacks are Possible with Spoofed SSL Servers** in org.apache.httpcomponents:httpclient:4.2.1
 - **Improper Certificate Common Name Verification Allows Spoofing SSL Servers** in org.apache.httpcomponents:httpclient:4.2.1

srcclr-pr-id-43a70dc26461934b3c36f4d3d4a3908748b1a74b201a7a301d13a2508acbe729
